### PR TITLE
emqx: add 'emqx' to beam boot log

### DIFF
--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -90,9 +90,9 @@ static char erts_system_version[] = ("Erlang/OTP " ERLANG_OTP_RELEASE
 				     " [erts-" ERLANG_VERSION "]"
 #ifndef OTP_RELEASE
 #ifdef ERLANG_GIT_VERSION
-				     " [source-" ERLANG_GIT_VERSION "]"
+				     " [emqx-" ERLANG_GIT_VERSION "]"
 #else
-				     " [source]"
+				     " [emqx]"
 #endif
 #endif	
 #ifdef ARCH_64


### PR DESCRIPTION
before:
`Erlang/OTP 23 [erts-11.2] [source-b0cf067b99] [64-bit] ...`

after:
`Erlang/OTP 23 [erts-11.2] [emqx-b0cf067b99] [64-bit] ...`