### PR TITLE
Mnesia/arg send table batch size

### DIFF
--- a/lib/mnesia/src/mnesia_loader.erl
+++ b/lib/mnesia/src/mnesia_loader.erl
@@ -744,7 +744,17 @@ do_send_table(Pid, Tab, Storage, RemoteS) ->
 	    Storage ->
 		%% Send first
 		TabSize = mnesia:table_info(Tab, size),
-		KeysPerTransfer = calc_nokeys(Storage, Tab),
+		KeysPerTransfer =
+                case ?catch_val(send_table_batch_size) of
+                    {'EXIT', _} ->
+                        mnesia_lib:set(send_table_batch_size, 0),
+                        calc_nokeys(Storage, Tab);
+                    0 ->
+                        calc_nokeys(Storage, Tab);
+                    Val when is_integer(Val) ->
+                        Val
+                end,
+
 		ChunkData = dets:info(Tab, bchunk_format),
 
 		UseDetsChunk =

--- a/lib/mnesia/src/mnesia_monitor.erl
+++ b/lib/mnesia/src/mnesia_monitor.erl
@@ -691,6 +691,7 @@ env() ->
      no_table_loaders,
      dc_dump_limit,
      send_compressed,
+     send_table_batch_size,
      schema
     ].
 
@@ -741,6 +742,8 @@ default_env(dc_dump_limit) ->
     4;
 default_env(send_compressed) ->
     0;
+default_env(send_table_batch_size) ->
+    0;
 default_env(schema) ->
     [].
 
@@ -790,6 +793,7 @@ do_check_type(pid_sort_order, _) -> false;
 do_check_type(no_table_loaders, N) when is_integer(N), N > 0 -> N;
 do_check_type(dc_dump_limit,N) when is_number(N), N > 0 -> N;
 do_check_type(send_compressed, L) when is_integer(L), L >= 0, L =< 9 -> L;
+do_check_type(send_table_batch_size, L) when is_integer(L), L >= 0 -> L;
 do_check_type(schema, L) when is_list(L) -> L.
 
 bool(true) -> true;


### PR DESCRIPTION
New mnesia optional arg: `send_table_batch_size` to specify batch size when mnesia copies table from another node.

default value `0` means:  mnesia will calc a proper value as old behavior.

This is to solve a problem when the table under copying has avg large size record, that old behavior would prefer to use small batch size and the receiver is mostly blocking for the new inputs.