### PR TITLE
mnesia: copy table from a specified node.

### DIFF
--- a/lib/mnesia/src/mnesia_loader.erl
+++ b/lib/mnesia/src/mnesia_loader.erl
@@ -210,7 +210,19 @@ do_get_network_copy(Tab, _Reason, _Ns, unknown, _Cs) ->
     verbose("Local table copy of ~tp has recently been deleted, ignored.~n", [Tab]),
     {not_loaded, storage_unknown};
 do_get_network_copy(Tab, Reason, Ns, Storage, Cs) ->
-    [Node | Tail] = Ns,
+    [Node | Tail] =
+        case ?catch_val(copy_from_node) of
+            undefined -> Ns;
+            CPNode when is_atom(CPNode) ->
+                case lists:member(CPNode, Ns) of
+                    true ->
+                        [CPNode | Ns -- [CPNode]];
+                    false ->
+                        Ns
+                end;
+            _ ->
+                Ns
+        end,
     case lists:member(Node,val({current, db_nodes})) of
 	true ->
 	    dbg_out("Getting table ~tp (~p) from node ~p: ~tp~n",

--- a/lib/mnesia/src/mnesia_monitor.erl
+++ b/lib/mnesia/src/mnesia_monitor.erl
@@ -690,6 +690,7 @@ env() ->
      pid_sort_order,
      no_table_loaders,
      dc_dump_limit,
+     copy_from_node,
      send_compressed,
      schema
     ].
@@ -739,6 +740,8 @@ default_env(no_table_loaders) ->
     2;
 default_env(dc_dump_limit) ->
     4;
+default_env(copy_from_node) ->
+    undefined;
 default_env(send_compressed) ->
     0;
 default_env(schema) ->
@@ -789,6 +792,7 @@ do_check_type(pid_sort_order, "standard") -> standard;
 do_check_type(pid_sort_order, _) -> false;
 do_check_type(no_table_loaders, N) when is_integer(N), N > 0 -> N;
 do_check_type(dc_dump_limit,N) when is_number(N), N > 0 -> N;
+do_check_type(copy_from_node, L) when is_atom(L) -> L;
 do_check_type(send_compressed, L) when is_integer(L), L >= 0, L =< 9 -> L;
 do_check_type(schema, L) when is_list(L) -> L.
 


### PR DESCRIPTION
When a new node is added to the mnesia cluster, it selects a random node
to copy the table from if no 'master' node is defined (set master node
is not mandatory).

by setting arg: 'copy_from_node', operator is now free to choice
which node to copy from.

default is 'undefined', feature is disabled.

note, if the specified node is not in the candidates list, it will fallback to
default behavior.