### PR TITLE
memsup: configurable alarm src

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
     env:
       WXWIDGETS_VERSION: 3.1.4
     name: Build Erlang/OTP on Windows
-    runs-on: windows-latest
+    runs-on: windows-2019
     needs: pack
     steps:
       - uses: Vampire/setup-wsl@v1

--- a/lib/os_mon/src/memsup.erl
+++ b/lib/os_mon/src/memsup.erl
@@ -344,28 +344,39 @@ handle_cast(_Msg, State) ->
 
 %% It's time to check memory
 handle_info(time_to_collect, State) ->
-    case State#state.wd_timer of
-	undefined ->
+    MemInfoSrc = application:get_env(os_mon, meminfo_src, collect_sys),
+    IsPort = State#state.port_mode,
+    case {State#state.wd_timer, State#state.ext_wd_timer} of
+	{undefined, undefined} when IsPort ->
 	    WDTimer = erlang:send_after(State#state.helper_timeout,
-					self(),
-					reg_collection_timeout),
-	    if
-		State#state.port_mode ->
-		    State#state.pid ! {self(), collect_sys},
-		    {noreply, State#state{wd_timer=WDTimer,
-					  pending=[reg]}};
-		true ->
-		    OS = State#state.os,
-		    Self = self(),
-		    Pid = spawn_link(fun() ->
+					self(), reg_collection_timeout),
+        State#state.pid ! {self(), MemInfoSrc},
+        NewState = case MemInfoSrc of
+                       collect_sys ->
+                           State#state{wd_timer=WDTimer, pending=[reg]};
+                       collect_ext_sys ->
+                           State#state{ext_wd_timer=WDTimer, ext_pending=[reg]}
+                   end,
+		{noreply, NewState};
+	{undefined, undefined} when not IsPort ->
+        WDTimer = erlang:send_after(State#state.helper_timeout,
+					self(), reg_collection_timeout),
+		OS = State#state.os,
+		Self = self(),
+		Pid = spawn_link(fun() ->
 					     MU = get_memory_usage(OS),
 					     Self ! {collected_sys,MU}
 				     end),
-		    {noreply, State#state{pid=Pid, wd_timer=WDTimer,
-					  pending=[reg]}}
-	    end;
-	_TimerRef ->
-	    {noreply, State#state{pending=[reg|State#state.pending]}}
+		{noreply, State#state{pid=Pid, wd_timer=WDTimer,
+					  pending=[reg]}};
+	{_, undefined} ->
+        {noreply, State#state{pending=[reg|State#state.pending]}};
+	{undefined, _} when IsPort ->
+        {noreply, State#state{ext_pending=[reg|State#state.ext_pending]}};
+    _ when IsPort andalso collect_ext_sys =:= MemInfoSrc ->
+            {noreply, State#state{ext_pending=[reg|State#state.ext_pending]}};
+    _ ->
+            {noreply, State#state{pending=[reg|State#state.pending]}}
     end;
 
 %% Memory data collected
@@ -394,27 +405,8 @@ handle_info({collected_sys, {Alloc,Total}}, State) ->
 		    true ->
 			clear_alarm(system_memory_high_watermark)
 		end,
-
 		%% Check if process data should be collected
-		case State#state.sys_only of
-		    false ->
-			{Pid, Bytes} = get_worst_memory_user(),
-			Threshold= State#state.proc_mem_watermark*Total,
-
-			%% Check if process alarm should be set/cleared
-			if
-			    Bytes > Threshold ->
-				set_alarm(process_memory_high_watermark,
-					  Pid);
-			    true ->
-				clear_alarm(process_memory_high_watermark)
-			end,
-			
-			State#state{mem_usage={Alloc, Total},
-				    worst_mem_user={Pid, Bytes}};
-		    true ->
-			State#state{mem_usage={Alloc, Total}}
-		end;
+        maybe_check_process_mem(State, {Alloc, Total});
 	    false ->
 		State
 	end,
@@ -492,8 +484,23 @@ handle_info({collected_ext_sys, SysMemUsage}, State) ->
 
     %% Send the reply to all waiting clients, preserving time order
     reply(State#state.ext_pending, undef, SysMemUsage),
-
-    {noreply, State#state{ext_wd_timer=undefined, ext_pending=[]}};
+    Total = proplists:get_value(system_total_memory, SysMemUsage),
+    Alloc = Total - proplists:get_value(available_memory, SysMemUsage),
+    case lists:member(reg, State#state.ext_pending) of
+        true ->
+            if
+                Alloc > State#state.sys_mem_watermark*Total ->
+                    set_alarm(system_memory_high_watermark, []);
+                true ->
+                    clear_alarm(system_memory_high_watermark)
+            end,
+            erlang:send_after(State#state.timeout, self(), time_to_collect),
+            ok;
+        false ->
+            skip
+    end,
+    NewState = maybe_check_process_mem(State, {Alloc, Total}),
+    {noreply, NewState#state{ext_wd_timer=undefined, ext_pending=[]}};
 
 %% Timeout during ext memory data collection (port_mode==true only)
 handle_info(ext_collection_timeout, State) ->
@@ -843,6 +850,21 @@ clear_alarms() ->
 		  end,
 		  get()).
 
+maybe_check_process_mem(#state{ sys_only = false } = State, {Alloc, Total}) ->
+    {Pid, Bytes} = get_worst_memory_user(),
+    Threshold = State#state.proc_mem_watermark*Total,
+    if
+        Bytes > Threshold ->
+            set_alarm(process_memory_high_watermark, Pid);
+
+        true ->
+            clear_alarm(process_memory_high_watermark)
+    end,
+    State#state{mem_usage={Alloc, Total},
+                worst_mem_user={Pid, Bytes}};
+maybe_check_process_mem(State, _) ->
+    State.
+
 %%--Auxiliary-----------------------------------------------------------
 
 %% Type conversions
@@ -857,3 +879,4 @@ flush(Msg) ->
     after 0 ->
 	    true
     end.
+

--- a/lib/os_mon/test/memsup_SUITE.erl
+++ b/lib/os_mon/test/memsup_SUITE.erl
@@ -21,8 +21,9 @@
 -include_lib("common_test/include/ct.hrl").
 
 %% Test server specific exports
--export([all/0, suite/0]).
+-export([all/0, groups/0, suite/0]).
 -export([init_per_suite/1, end_per_suite/1]).
+-export([init_per_group/2, end_per_group/2]).
 -export([init_per_testcase/2, end_per_testcase/2]).
 
 %% Test cases
@@ -52,7 +53,20 @@ end_per_suite(Config) when is_list(Config) ->
     ok = application:stop(os_mon),
     Config.
 
+
+init_per_group(mem_src_ext_sys, Config) ->
+    application:set_env(os_mon, meminfo_src, collect_ext_sys),
+    Config;
+init_per_group(_, Config) ->
+    Config.
+
+end_per_group(mem_src_ext_sys, _Config) ->
+    application:unset_env(os_mon, meminfo_src);
+end_per_group(_, _Config) ->
+    ok.
+
 init_per_testcase(_Case, Config) ->
+    force_collection(),
     Config.
 
 end_per_testcase(_Case, _Config) ->
@@ -62,7 +76,17 @@ suite() ->
     [{ct_hooks,[ts_install_cth]},
      {timetrap,{minutes,1}}].
 
-all() -> 
+groups() ->
+    [{mem_src_sys, [], all_tcs()},
+     {mem_src_ext_sys, [], all_tcs()}
+    ].
+
+all() ->
+    [{group, mem_src_ext_sys},
+     {group, mem_src_sys}
+    ].
+
+all_tcs() ->
     All = case test_server:os_type() of
               {unix, sunos} ->
                   [api, alarm1, alarm2, process, config, timeout,
@@ -165,12 +189,9 @@ api(Config) when is_list(Config) ->
 
 %% Test alarms when memsup_system_only==false
 alarm1(Config) when is_list(Config) ->
-
     %% If system memory usage is too high, the testcase cannot
     %% be run correctly
-    {Total, Alloc, {_Pid,_PidAlloc}} = memsup:get_memory_data(),
-    io:format("alarm1: Total: ~p, Alloc: ~p~n", [Total, Alloc]),
-    SysUsage = Alloc/Total,
+    SysUsage = get_sys_mem_util(),
     if
         SysUsage > 0.99 ->
             {skip, sys_mem_too_high};
@@ -205,14 +226,11 @@ alarm1(_Config, SysUsage) ->
     end,
 
     %% Lower/raise the threshold to clear/set the alarm
-    NewSysThreshold = if
-                          SysP ->
-                              Value = 1.1*SysUsage,
-                              if
-                                  Value > 0.99 -> 0.99;
-                                  true -> Value
-                              end;
-                          not SysP -> 0.9*SysUsage
+    NewSysThreshold = case SysP of
+                          true ->
+                              1.0;
+                          false ->
+                              0.0
                       end,
 
     ok = memsup:set_sysmem_high_watermark(NewSysThreshold),
@@ -268,8 +286,8 @@ alarm1(_Config, SysUsage) ->
 
     %% Lower/raise the threshold to clear/set the alarm
     NewProcThreshold = if
-                           ProcP -> 1.1*PidUsage;
-                           not ProcP -> 0.9*PidUsage
+                           ProcP -> 1.0;
+                           not ProcP -> 0.0
                        end,
     ok = memsup:set_procmem_high_watermark(NewProcThreshold),
     ok = force_collection(),
@@ -309,8 +327,7 @@ alarm2(Config) when is_list(Config) ->
 
     %% If system memory usage is too high, the testcase cannot
     %% be run correctly
-    {Total, Alloc, {_Pid,_PidAlloc}} = memsup:get_memory_data(),
-    SysUsage = Alloc/Total,
+    SysUsage = get_sys_mem_util(),
     if
         SysUsage>0.99 ->
             {skip, sys_mem_too_high};
@@ -330,12 +347,12 @@ alarm2(_Config, _SysUsage) ->
     ok = memsup:set_check_interval(60),
 
     %% Check data and thresholds
-    {Total, Alloc, undefined} = memsup:get_memory_data(),
+    {_Total, _Alloc, undefined} = memsup:get_memory_data(),
     SysThreshold = (memsup:get_sysmem_high_watermark()/100),
     true = is_integer(memsup:get_procmem_high_watermark()),
 
     %% Check if a system alarm already should be set or not
-    SysUsage = Alloc/Total,
+    SysUsage = get_sys_mem_util(),
     SysP = if
                SysUsage>SysThreshold -> true;
                SysUsage=<SysThreshold -> false
@@ -354,13 +371,8 @@ alarm2(_Config, _SysUsage) ->
 
     %% Lower/raise the threshold to clear/set the alarm
     NewSysThreshold = if
-                          SysP ->
-                              Value = 1.1*SysUsage,
-                              if
-                                  Value > 0.99 -> 0.99;
-                                  true -> Value
-                              end;
-                          not SysP -> 0.9*SysUsage
+                          SysP -> 1.0;
+                          not SysP -> 0.0
                       end,
 
     ok = memsup:set_sysmem_high_watermark(NewSysThreshold),
@@ -775,7 +787,8 @@ force_collection() ->
 
 force_collection(TimerRef) ->
     receive
-        {trace, _Pid, 'receive', {collected_sys, _Sys}} ->
+        {trace, _Pid, 'receive', {Tag, _Sys}}
+          when Tag=:=collected_sys orelse Tag=:=collected_ext_sys ->
             erlang:cancel_timer(TimerRef),
             erlang:trace(whereis(memsup), false, ['receive']),
             flush(),
@@ -785,7 +798,7 @@ force_collection(TimerRef) ->
             erlang:trace(whereis(memsup), false, ['receive']),
             flush(),
             collection_timeout;
-        timout ->
+        timeout ->
             erlang:trace(whereis(memsup), false, ['receive']),
             flush(),
             timeout;
@@ -819,3 +832,15 @@ start_node(Config, Args) when is_list(Config) ->
 
 stop_node(Node) ->
     test_server:stop_node(Node).
+
+get_sys_mem_util()->
+    case application:get_env(os_mon, meminfo_src, collect_sys) of
+        collect_ext_sys ->
+            MData = memsup:get_system_memory_data(),
+            Total = proplists:get_value(system_total_memory, MData),
+            Alloc = Total - proplists:get_value(available_memory, MData),
+            Alloc/Total;
+        collect_sys ->
+            {Total, Alloc, _} = memsup:get_memory_data(),
+            Alloc/Total
+    end.


### PR DESCRIPTION
memsup: configurable alarm src
    
    In Linux,
    
    For the runtime system that is managed by Linux cgroups such as lxc and
    docker container, erlang VM should read meminfo from procfs: /proc/meminfo to
    get correct view of memory usage and the limit.
    
    Currently 'memsup' supports read from procfs via memsup:get_system_memory_data/0.
    However the memsup alarm still reads via sysconf call.
    
    This commit adds a config switch to make memsup get alarm input from 'procfs'
    or 'sysconf call' via application env: 'meminfo_src'.
