### PR TITLE
Fix ci

### DIFF
--- a/.github/scripts/build-base-image.sh
+++ b/.github/scripts/build-base-image.sh
@@ -33,6 +33,9 @@ case "${BASE_BRANCH}" in
 esac
 
 case "${BASE_BRANCH}" in
+    emqx-OTP-*)
+        LATEST_ERLANG_VERSION="$(echo "$BASE_BRANCH" | grep -oP 'emqx-OTP-\K[0-9]+')"
+        ;;
     maint-*)
         LATEST_ERLANG_VERSION=${BASE_BRANCH#"maint-"}
         ;;

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,6 +35,8 @@ name: Build and check Erlang/OTP
 
 on:
   push:
+    tags:
+      - 'OTP-*'
   pull_request:
   schedule:
       - cron: 0 1 * * *


### PR DESCRIPTION
1. Only trigger build on `OTP-*` tag pushes, but not branch pushes
2. Parse OTP release major version from `emqx-OTP-*` branch name pattern (in addition to the upstream's `maint-*` pattern).

Without this ifx, if a PR is sent to OTP 27, without correctly parsing the major release version number, the CI job may result in some beam files compiled on OTP 28/29 which cannot be loaded on OTP 27.