### PR TITLE
Revert "fix(mqtt): allow application to check max packet size"

### DIFF
--- a/erts/emulator/beam/packet_parser.c
+++ b/erts/emulator/beam/packet_parser.c
@@ -502,19 +502,10 @@ int packet_get_length(enum PacketParseType htype,
         /* ERROR: variable byte integer >4 bytes long */
         goto error;
     packet:
-        if (max_plen != 0 && plen > max_plen) {
-            /* Application will only get the head of a too-large MQTT packet
-             * and should check frame length against max length again then
-             * send DISCONNECT with reason code 149 (packet-too-large).
-             * If application does not check size, the packet would
-             * appear to be malformed
-             */
-            return hlen;
-        }
         /* No special parsing for now */
         goto remain;
     }
-
+    
     default:
         DEBUGF((" => case error\r\n"));
         return -1;

--- a/erts/emulator/test/decode_packet_SUITE.erl
+++ b/erts/emulator/test/decode_packet_SUITE.erl
@@ -245,10 +245,6 @@ packet_size(Config) when is_list(Config) ->
                 case decode_pkt(Type,Bin,[{packet_size,Max}]) of
                     {ok,Unpacked,Rest} when Max=:=0; Max>=byte_size(Packet) ->
                         ok;
-                    {ok,Head,Tail} when Type =:= mqtt andalso byte_size(Unpacked) > Max ->
-                        true = (Bin =:= iolist_to_binary([Head,Tail])),
-                        {ok, Head, <<>>} = decode_pkt(Type,Head,[{packet_size,Max}]),
-                        ok;
                     {error,_} when Max<byte_size(Packet), Max=/=0 ->
                         ok;
                     {error,_} when Type=:=fcgi, Max=/=0 ->


### PR DESCRIPTION
This reverts commit 2023887f9b15563f1dea5e01f42d11629b613042. The fix only worked by chance, because often the remaining bytes are not valid MQTT packets hence result in a socket close before application can send the DISCONNECT packet.