### PR TITLE
feat: add process label in max heap reached error log

### DIFF
--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -3761,6 +3761,8 @@ reached_max_heap_size(Process *p, Uint total_heap_size,
     if (ERTS_IS_P_TRACED_FL(p, F_TRACE_GC) ||
         max_heap_flags & MAX_HEAP_SIZE_LOG) {
         Eterm msg;
+        Eterm label;
+        Uint label_sz=0;
         Uint size = 0;
         Eterm *o_hp , *hp;
         erts_process_gc_info(p, &size, NULL, extra_heap_size,
@@ -3780,6 +3782,7 @@ reached_max_heap_size(Process *p, Uint total_heap_size,
             if (alive)
                 erts_dsprintf(dsbufp, "on node ~p");
             erts_dsprintf(dsbufp, "~n     Context:            maximum heap size reached~n");
+            erts_dsprintf(dsbufp, "     Label:              ~p~n");
             erts_dsprintf(dsbufp, "     Max Heap Size:      ~p~n");
             erts_dsprintf(dsbufp, "     Total Heap Size:    ~p~n");
             erts_dsprintf(dsbufp, "     Kill:               ~p~n");
@@ -3792,7 +3795,14 @@ reached_max_heap_size(Process *p, Uint total_heap_size,
             erts_factory_tmp_init(&hfact, NULL, 0, ERTS_ALC_T_TMP);
             stacktrace = erts_build_stacktrace(&hfact, p, 0,
                                                erts_backtrace_depth, 1);
-            hp = erts_produce_heap(&hfact, 2*(alive ? 9 : 8), 0);
+            /* Extract process label from process dictionary */
+            /* Always print label: if not set, erts_pd_hash_get returns am_undefined */
+            label = erts_pd_hash_get(p, am_DollarProcessLabel);
+            label_sz = is_immed(label) ? 0 : size_object(label);
+            hp = erts_produce_heap(&hfact, 2*(alive ? 10 : 9) + label_sz, 0);
+            if (label_sz) {
+                label = copy_struct(label, label_sz, &hp, hfact.off_heap);
+            }
             args = CONS(hp, stacktrace, args); hp += 2;
             args = CONS(hp, msg, args); hp += 2;
             args = CONS(hp, make_small((p)->sig_qs.mq_len), args); hp += 2;
@@ -3800,6 +3810,7 @@ reached_max_heap_size(Process *p, Uint total_heap_size,
             args = CONS(hp, (max_heap_flags & MAX_HEAP_SIZE_KILL ? am_true : am_false), args); hp += 2;
             args = CONS(hp, make_small(total_heap_size), args); hp += 2;
             args = CONS(hp, make_small(MAX_HEAP_SIZE_GET(p)), args); hp += 2;
+            args = CONS(hp, label, args); hp += 2;
             if (alive) {
                 args = CONS(hp, erts_this_node->sysname, args); hp += 2;
             }


### PR DESCRIPTION
example log:

2025-10-31T20:36:58.339684+01:00 [error] Process:            <0.6678.0> on node 'emqx@127.0.0.1', Context:            maximum heap size reached, Label:              <<"0123456789012345678">>, Max Heap Size:      196608, Total Heap Size:    2313669, Kill:               true, Error Logger:       true, Message Queue Len:  15000, GC Info:            [{old_heap_block_size,4185},{heap_block_size,1206329},{mbuf_size,1103188},{recent_size,2549},{stack_size,28},{old_heap_size,1752},{heap_size,6739},{bin_vheap_size,7654},{bin_vheap_block_size,46422},{bin_old_vheap_size,2570},{bin_old_vheap_block_size,46422}], Stacktrace:         [{logger,add_default_metadata,2,[{file,"logger.erl"},{line,1962}]},{logger,log_allowed,4,[{file,"logger.erl"},{line,1887}]},{emqx_connection,handle_info,2,[{file,"emqx_connection.erl"},{line,1044}]},{emqx_connection,process_msg,2,[{file,"emqx_connection.erl"},{line,510}]},{emqx_connection,handle_recv,3,[{file,"emqx_connection.erl"},{line,441}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,340}]}]
