### PR TITLE
fix: tolerate DomainComponent encoded as PrintableString

### DIFF
--- a/lib/public_key/asn1/OTP-PKIX.asn1
+++ b/lib/public_key/asn1/OTP-PKIX.asn1
@@ -42,7 +42,7 @@ IMPORTS
        at-x520OrganizationName, at-x520OrganizationalUnitName, at-x520Title,
        at-x520dnQualifier, at-x520SerialNumber, at-x520Pseudonym,
        at-domainComponent, at-emailAddress,
-       id-at-countryName, id-emailAddress,
+       id-at-countryName, id-domainComponent, id-emailAddress,
        ub-emailaddress-length,
        Validity, Version, SubjectPublicKeyInfo,
        UniqueIdentifier,
@@ -142,11 +142,14 @@ OTPSupportedAttributes ATTRIBUTE ::= {
     at-x520LocalityName | at-x520StateOrProvinceName |
     at-x520OrganizationName | at-x520OrganizationalUnitName |
     at-x520Title | at-x520dnQualifier | otp-at-x520countryName |
-    at-x520SerialNumber | at-x520Pseudonym | at-domainComponent |
+    at-x520SerialNumber | at-x520Pseudonym | otp-at-domainComponent |
     otp-at-emailAddress, ... }
 
 otp-at-x520countryName ATTRIBUTE ::= {
     TYPE OTP-X520countryName IDENTIFIED BY id-at-countryName }
+
+otp-at-domainComponent ATTRIBUTE ::= {
+    TYPE OTP-DomainComponent IDENTIFIED BY id-domainComponent }
 
 otp-at-emailAddress ATTRIBUTE ::= {
     TYPE OTP-emailAddress IDENTIFIED BY id-emailAddress }
@@ -158,6 +161,15 @@ otp-at-emailAddress ATTRIBUTE ::= {
 OTP-X520countryName ::= CHOICE {
     correct           PrintableString (SIZE (2..3)), -- Correct size is 2.
     wrong             UTF8String      (SIZE (2..3))
+}
+
+ -- We accept PrintableString encoding of DomainComponent
+ -- which should be IA5String per RFC 2247, but some devices
+ -- use PrintableString.
+
+OTP-DomainComponent ::= CHOICE {
+    correct IA5String,
+    wrong PrintableString
 }
 
 OTP-emailAddress ::= CHOICE {

--- a/lib/public_key/src/pubkey_cert_records.erl
+++ b/lib/public_key/src/pubkey_cert_records.erl
@@ -95,6 +95,8 @@ enc_transform(#'AttributeTypeAndValue'{type=Id, value=Value0}) ->
     case Id of
         ?'id-at-countryName' ->
             #'SingleAttribute'{type=Id, value={correct, Value0}};
+        ?'id-domainComponent' ->
+            #'SingleAttribute'{type=Id, value={correct, Value0}};
         ?'id-emailAddress' ->
             #'SingleAttribute'{type=Id, value={correct, Value0}};
         _ ->
@@ -144,6 +146,8 @@ dec_transform({absent,'NULL'}) ->
 dec_transform(#'SingleAttribute'{type=Id,value=Value0}) ->
     case {Id, Value0} of
         {?'id-at-countryName', {_,String}} ->
+            #'AttributeTypeAndValue'{type=Id, value=String};
+        {?'id-domainComponent', {_,String}} ->
             #'AttributeTypeAndValue'{type=Id, value=String};
         {?'id-emailAddress', {_,String}} ->
             #'AttributeTypeAndValue'{type=Id, value=String};


### PR DESCRIPTION
## Summary
- Some devices encode the `DC` (DomainComponent) attribute in certificate DNs as `PrintableString` (ASN.1 tag 19) instead of `IA5String` (tag 22) required by RFC 2247
- This causes `public_key:pkix_decode_cert/2` to crash with `{wrong_tag,{{expected,22},{got,19,...}}}`
- Apply the same workaround pattern already used for `countryName` and `emailAddress`: define an `OTP-DomainComponent` CHOICE type accepting both encodings

## How to reproduce

```erlang
%% 1. Generate a normal cert with DC in subject
os:cmd("openssl req -x509 -newkey rsa:2048 -keyout /tmp/key.pem -out /tmp/cert.pem "
       "-days 365 -nodes -subj '/DC=example/CN=test'"),

%% 2. Read and patch: change IA5String tag (0x16) to PrintableString tag (0x13)
{ok, Pem} = file:read_file("/tmp/cert.pem"),
[{_, Der, _}] = public_key:pem_decode(Pem),
Bad = binary:replace(Der, <<16#16, 7, "example">>, <<16#13, 7, "example">>),

%% 3. Decode crashes
public_key:pkix_decode_cert(Bad, otp).
%% ** {wrong_tag,{{expected,22},{got,19,{19,<<"example">>}}}}
```

Note: the patched cert has an invalid signature, but the crash occurs during ASN.1 decoding before signature verification.

## Test plan
- [x] Bad cert (PrintableString DC) decodes successfully after fix
- [x] Good cert (IA5String DC) still decodes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)