### PR TITLE
feat: unblock Mria when parallel starts

### DIFF
--- a/lib/mnesia/src/mnesia_controller.erl
+++ b/lib/mnesia/src/mnesia_controller.erl
@@ -1660,6 +1660,9 @@ last_consistent_replica(Cs, Tab, Downs) ->
 	    true -> LocalMaster0
 	end,
     if
+    Tab == mria_schema orelse Tab =:= '$mria_rlog_sync' ->
+        %% For EMQX/mria
+        {true, {Tab, ram_only}};
 	Copies == [node()]  ->
 	    %% Only one copy holder and it is local.
 	    %% It may also be a local contents table


### PR DESCRIPTION
`mria_schema` and '$mria_rlog_sync' are for internal tables, they use 'null' ext storage but table type is ram_copies. (see mria_mnesia_null_storage).

Without this fix, Mria application may block when it is waiting for the better copies of these tables from other nodes within the cluster.

This fix makes Mria app starts so Mria ops will be possible.