### PR TITLE
mnesia: prevent 'unknown' storage from entering where_to_commit

### DIFF
--- a/lib/mnesia/src/mnesia_controller.erl
+++ b/lib/mnesia/src/mnesia_controller.erl
@@ -1711,9 +1711,26 @@ add_active_replica(Tab, Node) ->
     add_active_replica(Tab, Node, val({Tab, cstruct})).
 
 add_active_replica(Tab, Node, Cs = #cstruct{}) ->
-    Storage = mnesia_lib:schema_cs_to_storage_type(Node, Cs),
-    AccessMode = Cs#cstruct.access_mode,
-    add_active_replica(Tab, Node, Storage, AccessMode).
+    case mnesia_lib:cs_to_storage_type(Node, Cs) of
+	unknown when Cs#cstruct.name /= schema ->
+	    %% cstruct does not list Node as a copy holder of Tab. The
+	    %% caller's intent (register Node as an active replica) is
+	    %% incoherent with the schema. Trust the schema and purge any
+	    %% stale runtime state for Node on Tab. This self-heals leftover
+	    %% entries from a missed del_active_replica (netsplit recovery,
+	    %% reordered loaded notifications, etc.) and prevents
+	    %% mnesia_tm:prepare_node/5 from later crashing with
+	    %% {case_clause, unknown}.
+	    del_active_replica(Tab, Node);
+	unknown ->
+	    %% Schema table: preserve the historical fallback that treats
+	    %% unknown storage as ram_copies.
+	    AccessMode = Cs#cstruct.access_mode,
+	    add_active_replica(Tab, Node, ram_copies, AccessMode);
+	Storage ->
+	    AccessMode = Cs#cstruct.access_mode,
+	    add_active_replica(Tab, Node, Storage, AccessMode)
+    end.
 
 %% Block table primitives
 
@@ -1739,6 +1756,14 @@ mark_blocked_tab(false, Value) ->
 
 %%
 
+add_active_replica(Tab, Node, unknown, _AccessMode) ->
+    %% Defensive: arrived via the RPC path (handle_call({add_active_replica,
+    %% [Tab, ToNode, RemoteS, AccessMode], _})) with an 'unknown' storage
+    %% pushed in by a peer. Same reasoning as the cstruct-based variant
+    %% above: refuse to record {Node, unknown} and instead purge any stale
+    %% entry so where_to_commit / where_to_write / active_replicas stay
+    %% consistent with what the schema actually says about Node.
+    del_active_replica(Tab, Node);
 add_active_replica(Tab, Node, Storage, AccessMode) ->
     Var = {Tab, where_to_commit},
     {Blocked, Old} = is_tab_blocked(val(Var)),


### PR DESCRIPTION
`mnesia:dirty_delete/2` failed with `case_clause` when a remote node down：

```
(emqx@192.168.64.192)3> ekka_membership:leader().
'emqx@192.168.64.193'
(emqx@192.168.64.192)4> 2026-05-21T14:23:01.831598+08:00 [warning] [Router Helper] Node emqx@192.168.64.193 is down, cleaning up routes
2026-05-21T14:23:01.831703+08:00 [warning] [Registry] Node emqx@192.168.64.193 is down, cleaning up channels
2026-05-21T14:23:01.832349+08:00 [error] Generic server emqx_router_helper terminating. Reason: {{case_clause,unknown},[{mnesia_tm,prepare_node,5,[{file,"mnesia_tm.erl"},{line,1358}]},{mnesia_tm,prepare_nodes,5,[{file,"mnesia_tm.erl"},{line,1331}]},{mnesia_tm,prepare_items,5,[{file,"mnesia_tm.erl"},{line,1251}]},{mnesia_tm,dirty,2,[{file,"mnesia_tm.erl"},{line,1084}]},{emqx_router_helper,handle_info,2,[{file,"emqx_router_helper.erl"},{line,134}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,695}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,771}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,236}]}]}. Last message: {membership,{mnesia,down,'emqx@192.168.64.193'}}. State: #{nodes => []}.
2026-05-21T14:23:01.832515+08:00 [error] crasher: initial call: emqx_router_helper:init/1, pid: <0.2894.0>, registered_name: emqx_router_helper, error: {{case_clause,unknown},[{mnesia_tm,prepare_node,5,[{file,"mnesia_tm.erl"},{line,1358}]},{mnesia_tm,prepare_nodes,5,[{file,"mnesia_tm.erl"},{line,1331}]},{mnesia_tm,prepare_items,5,[{file,"mnesia_tm.erl"},{line,1251}]},{mnesia_tm,dirty,2,[{file,"mnesia_tm.erl"},{line,1084}]},{emqx_router_helper,handle_info,2,[{file,"emqx_router_helper.erl"},{line,134}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,695}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,771}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,236}]}]}, ancestors: [emqx_router_sup,emqx_sup,<0.2543.0>], message_queue_len: 0, messages: [], links: [<0.2893.0>], dictionary: [], trap_exit: false, status: running, heap_size: 6772, stack_size: 29, reductions: 19764; neighbours:
2026-05-21T14:23:01.832688+08:00 [error] Supervisor: {local,emqx_router_sup}. Context: child_terminated. Reason: {{case_clause,unknown},[{mnesia_tm,prepare_node,5,[{file,"mnesia_tm.erl"},{line,1358}]},{mnesia_tm,prepare_nodes,5,[{file,"mnesia_tm.erl"},{line,1331}]},{mnesia_tm,prepare_items,5,[{file,"mnesia_tm.erl"},{line,1251}]},{mnesia_tm,dirty,2,[{file,"mnesia_tm.erl"},{line,1084}]},{emqx_router_helper,handle_info,2,[{file,"emqx_router_helper.erl"},{line,134}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,695}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,771}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,236}]}]}. Offender: id=helper,pid=<0.2894.0>.
2026-05-21T14:23:01.832793+08:00 [error] Supervisor: {local,emqx_router_sup}. Context: shutdown. Reason: reached_max_restart_intensity. Offender: id=helper,pid=<0.2894.0>.
2026-05-21T14:23:01.833034+08:00 [error] Supervisor: {local,emqx_sup}. Context: child_terminated. Reason: shutdown. Offender: id=emqx_router_sup,pid=<0.2893.0>.
2026-05-21T14:23:01.833113+08:00 [error] Supervisor: {local,emqx_sup}. Context: shutdown. Reason: reached_max_restart_intensity. Offender: id=emqx_router_sup,pid=<0.2893.0>.
Stop http:dashboard listener on 0.0.0.0:18083 successfully.
Stop http:management listener on 0.0.0.0:8081 successfully.
[os_mon] memory supervisor port (memsup): Erlang has closed
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
{"Kernel pid terminated",application_controller,"{application_terminated,emqx,shutdown}"}
Kernel pid terminated (application_controller) ({application_terminated,emqx,shutdown})

Crash dump is being written to: log/crash.dump...done
```